### PR TITLE
new Util: concurrent.Gate

### DIFF
--- a/utils/src/main/java/io/redlink/utils/concurrent/Gate.java
+++ b/utils/src/main/java/io/redlink/utils/concurrent/Gate.java
@@ -22,6 +22,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
+/**
+ * A syncronization util that allows one or more threads to wait for until the <em>Gate</em> is <em>opened</em>.
+ *
+ * <p>A {@link Gate} is usually initialized in <em>closed</em> state, causing threads to {@link #await() wait} until
+ * the gate {@link #open() opens}.
+ * </p>
+ */
 public class Gate {
 
     private final ReentrantLock lock;
@@ -30,10 +37,17 @@ public class Gate {
 
     private long waitingCount;
 
+    /**
+     * Create a new, {@code closed} {@link Gate}.
+     */
     public Gate() {
         this(true);
     }
 
+    /**
+     * Create a new Gate with the given initial state.
+     * @param closed initial state of the created {@link Gate}
+     */
     public Gate(boolean closed) {
         lock = new ReentrantLock();
         hurdle = lock.newCondition();
@@ -41,6 +55,13 @@ public class Gate {
         waitingCount = 0L;
     }
 
+    /**
+     * Update the state of the Gate.
+     * @param closed the new state of the gate.
+     *
+     * @see #close()
+     * @see #open()
+     */
     public void setClosed(boolean closed) {
         if (closed) {
             close();
@@ -49,10 +70,26 @@ public class Gate {
         }
     }
 
+    /**
+     * Close the Gate! All further calls to {@link #await()} will block until the gate is {@link #open() opened} again.
+     *
+     * @see #open()
+     * @see #await()
+     * @see #await(Duration)
+     * @see #await(long, TimeUnit)
+     */
     public void close() {
         closed.compareAndSet(false, true);
     }
 
+    /**
+     * Open the Gate! All threads currently waiting in one of the {@link #await()}-methods will resume.
+     *
+     * @see #close()
+     * @see #await()
+     * @see #await(Duration)
+     * @see #await(long, TimeUnit)
+     */
     public void open() {
         if (closed.compareAndSet(true, false)) {
             lock.lock();
@@ -63,19 +100,64 @@ public class Gate {
             }
         }
     }
-    
+
+    /**
+     * Check the current state of the {@link Gate}
+     * @return {@code true} if the gate is currently closed.
+     *
+     * @see #isOpen()
+     * @see #close()
+     */
     public boolean isClosed() {
         return closed.get();
     }
-    
+
+    /**
+     * Check the current state of the {@link Gate}
+     * @return {@code true} if the gate is currently open.
+     *
+     * @see #isClosed()
+     * @see #open()
+     */
     public boolean isOpen() {
         return !isClosed();
     }
 
+    /**
+     * Retrieve the number threads currently waiting at the {@link Gate}
+     * @return the number of threads waiting at the gate.
+     */
     public long getWaitingCount() {
         return waitingCount;
     }
 
+    /**
+     * Causes the current thread to wait until the gate has opened, unless
+     * the thread is {@linkplain Thread#interrupt interrupted}.
+     *
+     * <p>If the gate is open then this method returns immediately.
+     *
+     * <p>If the gate is closed then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until one of two things
+     * happen:
+     * <ul>
+     * <li>The gate opens due to invocations of the
+     * {@link #open()} method; or
+     * <li>Some other thread {@linkplain Thread#interrupt interrupts}
+     * the current thread.
+     * </ul>
+     *
+     * <p>If the current thread:
+     * <ul>
+     * <li>has its interrupted status set on entry to this method; or
+     * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+     * </ul>
+     * then {@link InterruptedException} is thrown and the current thread's
+     * interrupted status is cleared.
+     *
+     * @throws InterruptedException if the current thread is interrupted
+     *         while waiting
+     */
     public void await() throws InterruptedException {
         try {
             doAwait(false, 0L);
@@ -84,14 +166,119 @@ public class Gate {
         }
     }
 
+    /**
+     * Causes the current thread to wait until the gate has opened, unless
+     * the thread is {@linkplain Thread#interrupt interrupted},
+     * or the specified waiting time elapses.
+     *
+     * <p>If the gate is open then this method returns immediately.
+     *
+     * <p>If the gate is closed then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until one of two things
+     * happen:
+     * <ul>
+     * <li>The gate opens due to invocations of the
+     * {@link #open()} method; or
+     * <li>Some other thread {@linkplain Thread#interrupt interrupts}
+     * the current thread.
+     * </ul>
+     *
+     * <p>If the current thread:
+     * <ul>
+     * <li>has its interrupted status set on entry to this method; or
+     * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+     * </ul>
+     * then {@link InterruptedException} is thrown and the current thread's
+     * interrupted status is cleared.
+     *
+     * <p>If the specified waiting time elapses then {@link TimeoutException}
+     * is thrown. If the time is less than or equal to zero, the
+     * method will not wait at all.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit the time unit of the {@code timeout} argument
+     * @throws TimeoutException if the specified timeout elapses.
+     * @throws InterruptedException if the current thread is interrupted
+     *         while waiting
+     */
     public void await(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
         doAwait(true, unit.toNanos(timeout));
     }
 
+    /**
+     * Causes the current thread to wait until the gate has opened, unless
+     * the thread is {@linkplain Thread#interrupt interrupted},
+     * or the specified waiting time elapses.
+     *
+     * <p>If the gate is open then this method returns immediately.
+     *
+     * <p>If the gate is closed then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until one of two things
+     * happen:
+     * <ul>
+     * <li>The gate opens due to invocations of the
+     * {@link #open()} method; or
+     * <li>Some other thread {@linkplain Thread#interrupt interrupts}
+     * the current thread.
+     * </ul>
+     *
+     * <p>If the current thread:
+     * <ul>
+     * <li>has its interrupted status set on entry to this method; or
+     * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+     * </ul>
+     * then {@link InterruptedException} is thrown and the current thread's
+     * interrupted status is cleared.
+     *
+     * <p>If the specified waiting time elapses then {@link TimeoutException}
+     * is thrown. If the time is less than or equal to zero, the
+     * method will not wait at all.
+     *
+     * @param timeout the maximum time to wait
+     * @throws TimeoutException if the specified timeout elapses.
+     * @throws InterruptedException if the current thread is interrupted
+     *         while waiting
+     */
     public void await(Duration timeout) throws InterruptedException, TimeoutException {
         doAwait(true, timeout.toNanos());
     }
 
+    /**
+     * Causes the current thread to wait until the gate has opened, unless
+     * the thread is {@linkplain Thread#interrupt interrupted},
+     * or the specified waiting time elapses.
+     *
+     * <p>If the gate is open then this method returns immediately.
+     *
+     * <p>If the gate is closed then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until one of two things
+     * happen:
+     * <ul>
+     * <li>The gate opens due to invocations of the
+     * {@link #open()} method; or
+     * <li>Some other thread {@linkplain Thread#interrupt interrupts}
+     * the current thread.
+     * </ul>
+     *
+     * <p>If the current thread:
+     * <ul>
+     * <li>has its interrupted status set on entry to this method; or
+     * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+     * </ul>
+     * then {@link InterruptedException} is thrown and the current thread's
+     * interrupted status is cleared.
+     *
+     * <p>If the specified waiting time elapses then the value {@code false}
+     * is returned.  If the time is less than or equal to zero, the method
+     * will not wait at all.
+     *
+     * @param timeout the maximum time to wait
+     * @param unit the time unit of the {@code timeout} argument
+     * @return {@code true} if the count reached zero and {@code false}
+     *         if the waiting time elapsed before the count reached zero
+     * @throws InterruptedException if the current thread is interrupted
+     *         while waiting
+     */
     public boolean tryAwait(long timeout, TimeUnit unit) throws InterruptedException {
         try {
             await(timeout, unit);
@@ -101,6 +288,41 @@ public class Gate {
         }
     }
 
+    /**
+     * Causes the current thread to wait until the gate has opened, unless
+     * the thread is {@linkplain Thread#interrupt interrupted},
+     * or the specified waiting time elapses.
+     *
+     * <p>If the gate is open then this method returns immediately.
+     *
+     * <p>If the gate is closed then the current thread becomes disabled
+     * for thread scheduling purposes and lies dormant until one of two things
+     * happen:
+     * <ul>
+     * <li>The gate opens due to invocations of the
+     * {@link #open()} method; or
+     * <li>Some other thread {@linkplain Thread#interrupt interrupts}
+     * the current thread.
+     * </ul>
+     *
+     * <p>If the current thread:
+     * <ul>
+     * <li>has its interrupted status set on entry to this method; or
+     * <li>is {@linkplain Thread#interrupt interrupted} while waiting,
+     * </ul>
+     * then {@link InterruptedException} is thrown and the current thread's
+     * interrupted status is cleared.
+     *
+     * <p>If the specified waiting time elapses then the value {@code false}
+     * is returned.  If the time is less than or equal to zero, the method
+     * will not wait at all.
+     *
+     * @param timeout the maximum time to wait
+     * @return {@code true} if the count reached zero and {@code false}
+     *         if the waiting time elapsed before the count reached zero
+     * @throws InterruptedException if the current thread is interrupted
+     *         while waiting
+     */
     public boolean tryAwait(Duration timeout) throws InterruptedException {
         try {
             await(timeout);

--- a/utils/src/main/java/io/redlink/utils/concurrent/Gate.java
+++ b/utils/src/main/java/io/redlink/utils/concurrent/Gate.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.redlink.utils.concurrent;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class Gate {
+
+    private final ReentrantLock lock;
+    private final Condition hurdle;
+    private final AtomicBoolean closed;
+
+    private long waitingCount;
+
+    public Gate() {
+        this(true);
+    }
+
+    public Gate(boolean closed) {
+        lock = new ReentrantLock();
+        hurdle = lock.newCondition();
+        this.closed = new AtomicBoolean(closed);
+        waitingCount = 0L;
+    }
+
+    public void setClosed(boolean closed) {
+        if (closed) {
+            close();
+        } else {
+            open();
+        }
+    }
+
+    public void close() {
+        closed.compareAndSet(false, true);
+    }
+
+    public void open() {
+        if (closed.compareAndSet(true, false)) {
+            lock.lock();
+            try {
+                hurdle.signalAll();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+    
+    public boolean isClosed() {
+        return closed.get();
+    }
+    
+    public boolean isOpen() {
+        return !isClosed();
+    }
+
+    public long getWaitingCount() {
+        return waitingCount;
+    }
+
+    public void await() throws InterruptedException {
+        try {
+            doAwait(false, 0L);
+        } catch (TimeoutException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public void await(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+        doAwait(true, unit.toNanos(timeout));
+    }
+
+    public void await(Duration timeout) throws InterruptedException, TimeoutException {
+        doAwait(true, timeout.toNanos());
+    }
+
+    public boolean tryAwait(long timeout, TimeUnit unit) throws InterruptedException {
+        try {
+            await(timeout, unit);
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+
+    public boolean tryAwait(Duration timeout) throws InterruptedException {
+        try {
+            await(timeout);
+            return true;
+        } catch (TimeoutException e) {
+            return false;
+        }
+    }
+
+    private void doAwait(boolean timed, long timeoutNanos) throws InterruptedException, TimeoutException {
+        // FASTLANE
+        if (!closed.get()) {
+            return;
+        }
+
+        lock.lock();
+        try {
+            long timeout = timeoutNanos;
+            waitingCount++;
+            while (closed.get()) {
+                if (!timed) {
+                    hurdle.await();
+                } else if (timeout > 0L) {
+                    timeout = hurdle.awaitNanos(timeout);
+                }
+
+                if (timed && timeout <= 0L) {
+                    throw new TimeoutException();
+                }
+            }
+        } finally {
+            waitingCount--;
+            lock.unlock();
+        }
+    }
+
+}

--- a/utils/src/test/java/io/redlink/utils/concurrent/GateTest.java
+++ b/utils/src/test/java/io/redlink/utils/concurrent/GateTest.java
@@ -66,7 +66,6 @@ public class GateTest {
         final Future<Long> f15 = createWorker(gate, Duration.ofSeconds(15), 15L);
         final Future<Long> f20 = createWorker(gate, Duration.ofSeconds(15), 20L);
 
-        assertThat("Two threads waiting", gate.getWaitingCount(), Matchers.is(2L));
         try {
             f15.get(1, TimeUnit.MILLISECONDS);
             fail("The gate was broken!");
@@ -75,6 +74,7 @@ public class GateTest {
         } catch (TimeoutException e) {
             // expected
         }
+        assertThat("Two threads waiting", gate.getWaitingCount(), Matchers.is(2L));
 
         gate.open();
         try {
@@ -162,6 +162,7 @@ public class GateTest {
                 future.completeExceptionally(e);
             }
         }).start();
+
         blocker.await();
         return future;
     }

--- a/utils/src/test/java/io/redlink/utils/concurrent/GateTest.java
+++ b/utils/src/test/java/io/redlink/utils/concurrent/GateTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2020 Redlink GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.redlink.utils.concurrent;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class GateTest {
+
+    @Test
+    public void testStateCheck() {
+        final Gate gate = new Gate();
+        assertTrue("Initial State is closed", gate.isClosed());
+        gate.open();
+        assertTrue("Gate is opened", gate.isOpen());
+        assertFalse("Gate is not closed", gate.isClosed());
+        gate.close();
+        assertFalse("Gate is not opened", gate.isOpen());
+        assertTrue("Gate is closed", gate.isClosed());
+
+        gate.setClosed(false);
+        assertTrue("Gate is open", gate.isOpen());
+        gate.setClosed(true);
+        assertTrue("Gate is closed", gate.isClosed());
+    }
+
+    @Test(timeout = 5L)
+    public void testOpenGate() throws InterruptedException {
+        final Gate gate = new Gate(false);
+
+        Assert.assertTrue("Gate is open", gate.tryAwait(-1, TimeUnit.MILLISECONDS));
+        Assert.assertTrue("Gate is open", gate.tryAwait(Duration.ofMillis(1).negated()));
+    }
+
+    @Test
+    public void testSimpleSync() throws InterruptedException {
+        final Gate gate = new Gate(true);
+
+        final Future<Long> f15 = createWorker(gate, Duration.ofSeconds(15), 15L);
+        final Future<Long> f20 = createWorker(gate, Duration.ofSeconds(15), 20L);
+
+        assertThat("Two threads waiting", gate.getWaitingCount(), Matchers.is(2L));
+        try {
+            f15.get(1, TimeUnit.MILLISECONDS);
+            fail("The gate was broken!");
+        } catch (ExecutionException e) {
+            fail("Execution-Exception");
+        } catch (TimeoutException e) {
+            // expected
+        }
+
+        gate.open();
+        try {
+            assertThat("F15", f15.get(1, TimeUnit.MILLISECONDS), Matchers.is(15L));
+            assertThat("F20", f20.get(1, TimeUnit.MILLISECONDS), Matchers.is(20L));
+        } catch (ExecutionException | TimeoutException e) {
+            fail("Gate did not open!");
+        }
+    }
+
+    @Test
+    public void testWithTimout() throws InterruptedException, TimeoutException {
+        final Gate gate = new Gate();
+
+        final Future<Boolean> trueFuture = createWorker(gate, Duration.ofMillis(500), Boolean.TRUE);
+
+        try {
+            trueFuture.get(1, TimeUnit.SECONDS);
+            fail("This should not happen");
+        } catch (ExecutionException e) {
+            assertThat("Timeout expected", e.getCause(), Matchers.instanceOf(TimeoutException.class));
+        }
+    }
+
+    @Test
+    public void testTryAwait() throws InterruptedException {
+        final Gate gate = new Gate();
+
+        assertFalse("Gate opened", gate.tryAwait(Duration.ofMillis(5)));
+        assertFalse("Gate opened", gate.tryAwait(5, TimeUnit.MILLISECONDS));
+
+        gate.open();
+        assertTrue("Gate closed", gate.tryAwait(Duration.ofMillis(5)));
+        assertTrue("Gate closed", gate.tryAwait(5, TimeUnit.MILLISECONDS));
+    }
+
+    @Test(timeout = 100L)
+    public void testPlainAwait() throws InterruptedException {
+        final Gate gate = new Gate();
+
+        final AtomicBoolean success = new AtomicBoolean(false);
+        final CountDownLatch preBarrier = new CountDownLatch(1),
+                postBarrier = new CountDownLatch(1);
+        new Thread(() -> {
+            try {
+                preBarrier.countDown();
+                gate.await();
+                success.set(true);
+            } catch (InterruptedException e) {
+                success.set(false);
+                Thread.currentThread().interrupt();
+            } finally {
+                postBarrier.countDown();
+            }
+        }).start();
+
+        new Thread(() -> {
+            try {
+                preBarrier.await();
+                gate.open();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }).start();
+
+        gate.await();
+        postBarrier.await();
+        gate.await();
+        assertTrue("Awaited", success.get());
+
+    }
+
+    private static <T> Future<T> createWorker(Gate gate, Duration timeout, final T result) throws InterruptedException {
+        final CompletableFuture<T> future = new CompletableFuture<>();
+        final CountDownLatch blocker = new CountDownLatch(1);
+        new Thread(() -> {
+            try {
+                blocker.countDown();
+                gate.await(timeout);
+                future.complete(result);
+            } catch (InterruptedException e) {
+                future.completeExceptionally(e);
+                Thread.currentThread().interrupt();
+            } catch (TimeoutException e) {
+                future.completeExceptionally(e);
+            }
+        }).start();
+        blocker.await();
+        return future;
+    }
+}


### PR DESCRIPTION
Somehow similar to CountDownLatch, but reusable:

```
final Gate gate = new Gate();
gate.close();

// Thread 1
gate.await();

// Thread 2
gate.open();